### PR TITLE
Fix vague-time dipendency

### DIFF
--- a/install.js
+++ b/install.js
@@ -1,0 +1,6 @@
+var path = require('path');
+var fs = require('fs');
+
+var staticFolderPath = 'subsystems/webui/static';
+var vaguePath = path.relative(path.join(__dirname, staticFolderPath), require.resolve('vague-time'));
+fs.symlinkSync(vaguePath, path.join(staticFolderPath, 'vagueTime.js'));

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "node_modules/.bin/mocha -R spec",
-    "start": "node index.js"
+    "start": "node index.js",
+    "install": "node install.js"
   },
   "repository": "git@github.com:brikteknologier/roat.git",
   "author": "Magnus Hoff <magnus.hoff@brik.no>",

--- a/subsystems/webui/static/vagueTime.js
+++ b/subsystems/webui/static/vagueTime.js
@@ -1,1 +1,0 @@
-../../../node_modules/vague-time/src/vagueTime.js


### PR DESCRIPTION
Dynamically set path to vague-time package because NPM 3 has flat folders structure.
You can check that after install npm skips symlink because file is placed in different folder.
After this update file path will be resolved automatically during installation process.
